### PR TITLE
fix memory management of rttest_sample_buffer

### DIFF
--- a/rttest/include/rttest/rttest.h
+++ b/rttest/include/rttest/rttest.h
@@ -33,6 +33,8 @@ struct rttest_params
   int sched_priority;
   size_t stack_size;
 
+  // TODO(dirk-thomas) currently this pointer is never deallocated or copied
+  // so whatever value is being assigned must stay valid forever
   char * filename;
 };
 


### PR DESCRIPTION
Connect to #21.

http://ci.ros2.org/job/ci_linux/817/