### PR TITLE
Store filename string on the heap

### DIFF
--- a/rttest/examples/example_loop.c
+++ b/rttest/examples/example_loop.c
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
     perror("Couldn't lock memory");
     return -1;
   }
-  rttest_prefault_stack();
+  rttest_lock_and_prefault_dynamic();
 
   rttest_spin(my_loop_callback, NULL);
 

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -49,7 +49,7 @@ TEST(TestApi, read_args_get_params) {
   EXPECT_EQ(params.sched_priority, 42);
   EXPECT_EQ(params.sched_policy, SCHED_FIFO);
   EXPECT_EQ(params.stack_size, 100);
-  EXPECT_EQ(params.filename, "foo.txt");
+  EXPECT_EQ(strcmp(params.filename, "foo.txt"), 0);
   EXPECT_EQ(0, rttest_finish());
 }
 
@@ -70,7 +70,7 @@ TEST(TestApi, init) {
   EXPECT_EQ(params.sched_priority, 42);
   EXPECT_EQ(params.sched_policy, SCHED_FIFO);
   EXPECT_EQ(params.stack_size, stack_size);
-  EXPECT_EQ(params.filename, "foo.txt");
+  EXPECT_EQ(strcmp(params.filename, "foo.txt"), 0);
 
   EXPECT_EQ(0, rttest_finish());
 }


### PR DESCRIPTION
Probably won't fix the mysterious memory issues reported in #21 (if they still persist; I wasn't able to reproduce the segfault). If a filename is given on the command line, allocate it on the heap and deallocate it on cleanup. Also, check if the allocated pointer is NULL whenever `malloc` is called.