### PR TITLE
uint32 -> long in a few places for time calculation

### DIFF
--- a/rttest/include/rttest/utils.h
+++ b/rttest/include/rttest/utils.h
@@ -65,12 +65,12 @@ static inline bool subtract_timespecs(const struct timespec * t1,
   return true;
 }
 
-static inline uint32_t timespec_to_long(const struct timespec * t)
+static inline uint64_t timespec_to_long(const struct timespec * t)
 {
   return t->tv_sec * NSEC_PER_SEC + t->tv_nsec;
 }
 
-static inline void long_to_timespec(const uint32_t input, struct timespec * t)
+static inline void long_to_timespec(const uint64_t input, struct timespec * t)
 {
   uint32_t nsecs = input % 1000000000;
   uint32_t secs = (input - nsecs) / 1000000000;
@@ -81,7 +81,7 @@ static inline void long_to_timespec(const uint32_t input, struct timespec * t)
 static inline void multiply_timespec(const struct timespec * t, const uint32_t i,
   struct timespec * result)
 {
-  uint32_t result_nsec = i * timespec_to_long(t);
+  uint64_t result_nsec = i * timespec_to_long(t);
   long_to_timespec(result_nsec, result);
 }
 


### PR DESCRIPTION
a few trivial tweaks to ensure we get 64-bit calcuation of time multiplications and diffs