### PR TITLE
remove non-existent target dependency

### DIFF
--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -43,7 +43,7 @@ if(AMENT_ENABLE_TESTING)
       target_compile_definitions(${target}${target_suffix}
         PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
       ament_target_dependencies(${target}${target_suffix}
-        "rclcpp${target_suffix}" "std_msgs" "tlsf_cpp" "tlsf")
+        "rclcpp${target_suffix}" "std_msgs" "tlsf")
     endif()
   endmacro()
 

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -42,7 +42,6 @@ if(AMENT_ENABLE_TESTING)
         ${_AMENT_EXPORT_LIBRARY_TARGETS})
       target_compile_definitions(${target}${target_suffix}
         PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-      add_dependencies(${target}${target_suffix} ${PROJECT_NAME})
       ament_target_dependencies(${target}${target_suffix}
         "rclcpp${target_suffix}" "std_msgs" "tlsf_cpp" "tlsf")
     endif()


### PR DESCRIPTION
`${PROJECT_NAME}` is not a valid target in this CMake file as far as I can see.