### PR TITLE
Clean up allocator for gcc 5.3

### DIFF
--- a/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
+++ b/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
@@ -27,26 +27,8 @@
 
 // Custom allocator deleter
 
-// Necessary for using custom allocator with std::basic_string in GCC 4.8
-// See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56437
-template<typename T>
-struct allocator_pointer_traits
-{
-  using size_type = std::size_t;
-  using pointer = T *;
-  using const_pointer = const pointer;
-  using difference_type = typename std::pointer_traits<pointer>::difference_type;
-  using reference = T &;
-  using const_reference = const reference;
-};
-
-template<>
-struct allocator_pointer_traits<void>
-{
-};
-
 template<typename T, size_t DefaultPoolSize = 1024 *1024>
-struct tlsf_heap_allocator : public allocator_pointer_traits<T>
+struct tlsf_heap_allocator
 {
   // Needed for std::allocator_traits
   using value_type = T;

--- a/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
+++ b/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
@@ -25,8 +25,6 @@
 
 #include "tlsf/tlsf.h"
 
-// Custom allocator deleter
-
 template<typename T, size_t DefaultPoolSize = 1024 *1024>
 struct tlsf_heap_allocator
 {
@@ -92,21 +90,6 @@ struct tlsf_heap_allocator
   void deallocate(T * ptr, size_t)
   {
     tlsf_free(ptr);
-  }
-
-  template<typename U, typename ... Args,
-  typename std::enable_if<!std::is_const<U>::value>::type * = nullptr>
-  void
-  construct(U * ptr, Args && ... args)
-  {
-    ::new(ptr)U(std::forward<Args>(args) ...);
-  }
-
-  template<typename U>
-  void
-  destroy(U * ptr)
-  {
-    ptr->~U();
   }
 
   template<typename U>

--- a/tlsf_cpp/test/test_tlsf.cpp
+++ b/tlsf_cpp/test/test_tlsf.cpp
@@ -240,25 +240,6 @@ void operator delete(void * ptr) noexcept
 #pragma GCC diagnostic pop
 }
 
-void operator delete(void * ptr, size_t) noexcept
-{
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  __malloc_hook = prev_malloc_hook;
-
-  if (ptr != nullptr) {
-    if (test_init) {
-      // Check the stacktrace to see the call originated in librmw or a DDS implementation
-      fail |= !check_stacktrace(rmw_tokens, num_rmw_tokens);
-    }
-
-    std::free(ptr);
-    ptr = nullptr;
-  }
-  __malloc_hook = testing_malloc;
-#pragma GCC diagnostic pop
-}
-
 template<typename T = void>
 using TLSFAllocator = tlsf_heap_allocator<T>;
 


### PR DESCRIPTION
Connects to #37

**Do not merge until we update to Xenial; this will break the build with the default gcc on Trusty.**