### PR TITLE
remove usage of internal variables and noops

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -20,7 +20,8 @@ if(${ament_cmake_FOUND})
   target_link_libraries(rttest m stdc++ ${CMAKE_THREAD_LIBS_INIT})
 
   ament_export_include_directories(include)
-  ament_export_libraries(rttest pthread)
+  set(exported_libraries rttest pthread)
+  ament_export_libraries(${exported_libraries})
 
   if(BUILD_TESTING)
     find_package(ament_cmake_gtest REQUIRED)
@@ -33,12 +34,8 @@ if(${ament_cmake_FOUND})
       TIMEOUT 15
     )
     if(TARGET gtest_rttest_api)
-      target_link_libraries(gtest_rttest_api
-        ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}
-        ${_AMENT_EXPORT_LIBRARY_TARGETS})
-      add_dependencies(gtest_rttest_api ${PROJECT_NAME})
-      ament_target_dependencies(gtest_rttest_api "rttest")
-      target_include_directories(gtest_rttest_api PUBLIC include)
+      target_link_libraries(gtest_rttest_api ${exported_libraries})
+      ament_target_dependencies(gtest_rttest_api ${PROJECT_NAME})
     endif()
   endif()
 

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -37,9 +37,6 @@ if(BUILD_TESTING)
     ament_add_gtest(${target}${target_suffix} "test/test_tlsf.cpp" TIMEOUT 15
       ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
     if(TARGET ${target}${target_suffix})
-      target_link_libraries(${target}${target_suffix}
-        ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}
-        ${_AMENT_EXPORT_LIBRARY_TARGETS})
       target_compile_definitions(${target}${target_suffix}
         PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
       ament_target_dependencies(${target}${target_suffix}


### PR DESCRIPTION
`rttest` must not rely on internal implementation details but use a variable to use the list of libraries in multiple places.

Since `tlsf_cpp`doesn't export any libraries using these variables doesn't make any sense.

Please review.