### PR TITLE
no need for test_depend if already exec_depend

### DIFF
--- a/tlsf_cpp/package.xml
+++ b/tlsf_cpp/package.xml
@@ -22,7 +22,6 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
-  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
follow up of https://github.com/ros2/examples/pull/134#discussion_r88093240
depends on https://github.com/ament/ament_tools/pull/124