### PR TITLE
Drop obsolete RTLinux

### DIFF
--- a/rttest/README.md
+++ b/rttest/README.md
@@ -1,9 +1,9 @@
-#rttest
+# rttest
 
 rttest is a minimal tool for instrumenting and running tests for synchronous real-time systems.
 It provides utilities for measuring and plotting jitter, latency, and missed deadlines.
 It also provides a library with macros for instrumenting code.
-It is designed with real-time Linux-based systems in mind, such as RTLinux/RT Preempt kernel.
+It is designed with real-time Linux-based systems in mind, such as [Preempt RT](https://wiki.linuxfoundation.org/realtime) kernel.
 
 ## Build instructions
 Build from source:


### PR DESCRIPTION
RTLinux is obsolete, and both commercial and GPL editions were no longer
maintained. Through the use of the real-time Linux kernel patch
PREEMPT_RT, support for full preemption of critical sections, interrupt
handlers, and "interrupt disable" code sequences can be supported.