### PR TITLE
install headers into the same location when ament_cmake is not used

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -81,7 +81,9 @@ else()
     ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
   )
 
-  install(FILES ${PROJECT_SOURCE_DIR}/include/rttest/rttest.h ${PROJECT_SOURCE_DIR}/include/rttest/utils.h DESTINATION ${INSTALL_INCLUDE_DIR})
+  install(
+    DIRECTORY include/
+    DESTINATION ${INSTALL_INCLUDE_DIR})
 
   export(PACKAGE ${PROJECT_NAME})
 


### PR DESCRIPTION
Closes #71.