### PR TITLE
Fix armhf build warnings

### DIFF
--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -594,8 +594,8 @@ int Rttest::spin_once(
     if (getrusage(RUSAGE_THREAD, &this->prev_usage) != 0) {
       return -1;
     }
-    printf("Initial major pagefaults: %zu\n", this->prev_usage.ru_majflt);
-    printf("Initial minor pagefaults: %zu\n", this->prev_usage.ru_minflt);
+    printf("Initial major pagefaults: %ld\n", this->prev_usage.ru_majflt);
+    printf("Initial minor pagefaults: %ld\n", this->prev_usage.ru_minflt);
   }
   struct timespec wakeup_time, current_time;
   multiply_timespec(update_period, i, &wakeup_time);

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -25,7 +25,7 @@ void * test_callback(void * args)
   size_t * counter = static_cast<size_t *>(args);
   /*ASSERT_TRUE(counter != NULL);*/
   *counter = *counter + 1;
-  printf("Test callback: %lu\n", *counter);
+  printf("Test callback: %zu\n", *counter);
 
   return 0;
 }


### PR DESCRIPTION
Fix armhf build warnings caused by incorrect format specifiers.
Build warnings: [src](https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/36/warnings23Result/package.767540328/) and [test](https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/36/warnings23Result/package.-1976035698/)

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>