### PR TITLE
Use a uint64_t to store the prefault_dynamic_size.

### DIFF
--- a/rttest/include/rttest/rttest.h
+++ b/rttest/include/rttest/rttest.h
@@ -33,7 +33,7 @@ struct rttest_params
   size_t sched_policy;
   int sched_priority;
   size_t stack_size;
-  size_t prefault_dynamic_size;
+  uint64_t prefault_dynamic_size;
 
   // TODO(dirk-thomas) currently this pointer is never deallocated or copied
   // so whatever value is being assigned must stay valid forever
@@ -74,7 +74,7 @@ int rttest_read_args(int argc, char ** argv);
 int rttest_init(
   size_t iterations, struct timespec update_period,
   size_t sched_policy, int sched_priority, size_t stack_size,
-  size_t prefault_dynamic_size, char * filename);
+  uint64_t prefault_dynamic_size, char * filename);
 
 /// \brief Fill an rttest_params struct with the current rttest params.
 /// \param[in] params Reference to the struct to fill in

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -63,7 +63,7 @@ TEST(TestApi, init) {
   update_period.tv_sec = 123;
   update_period.tv_nsec = 456;
   size_t stack_size = 100;
-  size_t prefault_dynamic_size = 100;
+  uint64_t prefault_dynamic_size = 100;
 
   EXPECT_EQ(
     0, rttest_init(


### PR DESCRIPTION
That way it works on 32-bit as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the build warnings on armhf: https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/409/warnings23Result/new/ .  @r7vme FYI