### PR TITLE
Convert timespec to uint64 not long and vice versa  (#94)

### DIFF
--- a/rttest/include/rttest/utils.h
+++ b/rttest/include/rttest/utils.h
@@ -68,25 +68,25 @@ static inline bool subtract_timespecs(
   return true;
 }
 
-static inline uint64_t timespec_to_long(const struct timespec * t)
+static inline uint64_t timespec_to_uint64(const struct timespec * t)
 {
-  return t->tv_sec * NSEC_PER_SEC + t->tv_nsec;
+  return static_cast<uint64_t>(t->tv_sec) * NSEC_PER_SEC + static_cast<uint64_t>(t->tv_nsec);
 }
 
-static inline void long_to_timespec(const uint64_t input, struct timespec * t)
+static inline void uint64_to_timespec(const uint64_t input, struct timespec * t)
 {
-  uint32_t nsecs = input % 1000000000;
-  uint32_t secs = (input - nsecs) / 1000000000;
-  t->tv_sec = secs;
-  t->tv_nsec = nsecs;
+  uint64_t nsecs = input % NSEC_PER_SEC;
+  uint64_t secs = (input - nsecs) / NSEC_PER_SEC;
+  t->tv_sec = static_cast<time_t>(secs);
+  t->tv_nsec = static_cast<long>(nsecs);
 }
 
 static inline void multiply_timespec(
   const struct timespec * t, const uint32_t i,
   struct timespec * result)
 {
-  uint64_t result_nsec = i * timespec_to_long(t);
-  long_to_timespec(result_nsec, result);
+  uint64_t result_nsec = i * timespec_to_uint64(t);
+  uint64_to_timespec(result_nsec, result);
 }
 
 #endif  // RTTEST__UTILS_H_

--- a/rttest/include/rttest/utils.h
+++ b/rttest/include/rttest/utils.h
@@ -78,7 +78,7 @@ static inline void uint64_to_timespec(const uint64_t input, struct timespec * t)
   uint64_t nsecs = input % NSEC_PER_SEC;
   uint64_t secs = (input - nsecs) / NSEC_PER_SEC;
   t->tv_sec = static_cast<time_t>(secs);
-  t->tv_nsec = static_cast<long>(nsecs);
+  t->tv_nsec = static_cast<long>(nsecs); // NOLINT for C type long
 }
 
 static inline void multiply_timespec(

--- a/rttest/include/rttest/utils.hpp
+++ b/rttest/include/rttest/utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RTTEST__UTILS_H_
-#define RTTEST__UTILS_H_
+#ifndef RTTEST__UTILS_HPP_
+#define RTTEST__UTILS_HPP_
 
 #include <stdint.h>
 #include <time.h>
@@ -89,4 +89,4 @@ static inline void multiply_timespec(
   uint64_to_timespec(result_nsec, result);
 }
 
-#endif  // RTTEST__UTILS_H_
+#endif  // RTTEST__UTILS_HPP_

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -316,18 +316,18 @@ int Rttest::read_args(int argc, char ** argv)
       case 'u':
         {
           // parse units
-          size_t nsec;
+          uint64_t nsec;
           std::string input(optarg);
           std::vector<std::string> tokens = {"ns", "us", "ms", "s"};
           for (size_t i = 0; i < 4; ++i) {
             size_t idx = input.find(tokens[i]);
             if (idx != std::string::npos) {
-              nsec = stol(input.substr(0, idx)) * pow(10, i * 3);
+              nsec = stoull(input.substr(0, idx)) * pow(10, i * 3);
               break;
             }
             if (i == 3) {
               // Default units are microseconds
-              nsec = stol(input) * 1000;
+              nsec = stoull(input) * 1000;
             }
           }
 

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -242,7 +242,7 @@ int Rttest::record_jitter(
   if (i >= this->sample_buffer.buffer_size) {
     return -1;
   }
-  this->sample_buffer.latency_samples[i] = parity * timespec_to_long(&jitter);
+  this->sample_buffer.latency_samples[i] = parity * timespec_to_uint64(&jitter);
   return 0;
 }
 
@@ -331,7 +331,7 @@ int Rttest::read_args(int argc, char ** argv)
             }
           }
 
-          long_to_timespec(nsec, &update_period);
+          uint64_to_timespec(nsec, &update_period);
         }
         break;
       case 't':
@@ -1011,7 +1011,7 @@ int Rttest::write_results_file(char * filename)
 
   fstream << "iteration timestamp latency minor_pagefaults major_pagefaults" << std::endl;
   for (size_t i = 0; i < this->sample_buffer.buffer_size; ++i) {
-    fstream << i << " " << timespec_to_long(&this->params.update_period) * i <<
+    fstream << i << " " << timespec_to_uint64(&this->params.update_period) * i <<
       " " << this->sample_buffer.latency_samples[i] << " " <<
       this->sample_buffer.minor_pagefaults[i] << " " <<
       this->sample_buffer.major_pagefaults[i] << std::endl;

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rttest/rttest.h>
-#include <rttest/utils.h>
 #include <rttest/math_utils.hpp>
+#include <rttest/rttest.h>
+#include <rttest/utils.hpp>
 
 #include <limits.h>
 #include <malloc.h>

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -18,7 +18,7 @@
 #include "gtest/gtest.h"
 
 #include "rttest/rttest.h"
-#include "rttest/utils.h"
+#include "rttest/utils.hpp"
 
 void * test_callback(void * args)
 {

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -146,7 +146,7 @@ TEST(TestApi, get_statistics) {
   EXPECT_EQ(runtime_maj_pgflts, results.major_pagefaults);
 
   // The average latency should be at least as large as the artificial pause
-  double expected_latency = static_cast<double>(timespec_to_long(&update_period));
+  double expected_latency = static_cast<double>(timespec_to_uint64(&update_period));
   EXPECT_GE(results.mean_latency, expected_latency);
 
   EXPECT_EQ(0, rttest_finish());

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -63,7 +63,7 @@ TEST(TestApi, read_args_update_period_over_32bit) {
   // 4294967305 equals "static_cast<uint64_t>(UINT32_MAX) + 10"
   // but avoid calculation to keep test simple
   uint64_t update_period = 4294967305;
-  std::string update_period_str("4294967305ns");
+  std::string update_period_str(std::to_string(update_period) + "ns");
   struct timespec t;
   uint64_to_timespec(update_period, &t);
 

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -193,18 +193,15 @@ TEST(TestApi, running) {
 
 TEST(TestApi, timespec_to_uint64) {
   // failed values in 32bit OS (#94)
-  time_t sec = 363464;
-  long nsec = 232837182; // NOLINT for C type long
-  uint64_t v = 363464232837182;
-
   struct timespec t;
-  t.tv_sec = sec;
-  t.tv_nsec = nsec;
+  t.tv_sec = 363464;
+  t.tv_nsec = 232837182;
+  uint64_t v = 363464232837182;
 
   EXPECT_EQ(v, timespec_to_uint64(&t));
 
   struct timespec t2;
   uint64_to_timespec(v, &t2);
-  EXPECT_EQ(sec, t2.tv_sec);
-  EXPECT_EQ(nsec, t2.tv_nsec);
+  EXPECT_EQ(t.tv_sec, t2.tv_sec);
+  EXPECT_EQ(t.tv_nsec, t2.tv_nsec);
 }

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -167,3 +167,21 @@ TEST(TestApi, running) {
   EXPECT_EQ(0, rttest_finish());
   EXPECT_EQ(0, rttest_running());
 }
+
+TEST(TestApi, timespec_to_uint64) {
+  // failed values in 32bit OS (#94)
+  time_t sec = 363464;
+  long nsec = 232837182; // NOLINT for C type long
+  uint64_t v = 363464232837182;
+
+  struct timespec t;
+  t.tv_sec = sec;
+  t.tv_nsec = nsec;
+
+  EXPECT_EQ(v, timespec_to_uint64(&t));
+
+  struct timespec t2;
+  uint64_to_timespec(v, &t2);
+  EXPECT_EQ(sec, t2.tv_sec);
+  EXPECT_EQ(nsec, t2.tv_nsec);
+}


### PR DESCRIPTION
UT is passed in 64bit(x86_64) and 32bit(Raspberry Pi).

