### PR TITLE
Only copy an rttest_sample_buffer if it is not nullptr.

### DIFF
--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -106,13 +106,9 @@ public:
   void operator=(const rttest_sample_buffer & other)
   {
     resize(other.buffer_size);
-    if (other.latency_samples != nullptr) {
+    if (this->buffer_size > 0) {
       memcpy(this->latency_samples, other.latency_samples, this->buffer_size * sizeof(int64_t));
-    }
-    if (other.major_pagefaults != nullptr) {
       memcpy(this->major_pagefaults, other.major_pagefaults, this->buffer_size * sizeof(size_t));
-    }
-    if (other.minor_pagefaults != nullptr) {
       memcpy(this->minor_pagefaults, other.minor_pagefaults, this->buffer_size * sizeof(size_t));
     }
   }


### PR DESCRIPTION
It is possible (though not likely) for an rttest_sample_buffer
to be copied before it ever has any data in it.  In that case,
we would be trying to copy from a nullptr, causing a crash.
Fix that here, along with the size of the latency_samples
copy.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>