### PR TITLE
Enable basic warnings in rttest

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 find_package(ament_cmake QUIET)
 

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -296,7 +296,6 @@ int Rttest::read_args(int argc, char ** argv)
   // -f,--filename
   // Don't write a file unless filename specified
   char * filename = nullptr;
-  int index;
   int c;
 
   std::string args_string = "i:u:p:t:s:m:d:f:r:";
@@ -500,8 +499,8 @@ int rttest_init(
 
 int Rttest::get_next_rusage(size_t i)
 {
-  size_t prev_maj_pagefaults = this->prev_usage.ru_majflt;
-  size_t prev_min_pagefaults = this->prev_usage.ru_minflt;
+  int64_t prev_maj_pagefaults = this->prev_usage.ru_majflt;
+  int64_t prev_min_pagefaults = this->prev_usage.ru_minflt;
   if (getrusage(RUSAGE_THREAD, &this->prev_usage) != 0) {
     return -1;
   }
@@ -741,8 +740,14 @@ int Rttest::lock_and_prefault_dynamic()
 
 int rttest_prefault_stack_size(const size_t stack_size)
 {
+  /*
   unsigned char stack[stack_size];
   memset(stack, 0, stack_size);
+  return 0;
+  */
+  unsigned char * stack = new unsigned char[stack_size];
+  memset(stack, 0, stack_size);
+  delete[] stack;
   return 0;
 }
 

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -499,8 +499,10 @@ int rttest_init(
 
 int Rttest::get_next_rusage(size_t i)
 {
-  int64_t prev_maj_pagefaults = this->prev_usage.ru_majflt;
-  int64_t prev_min_pagefaults = this->prev_usage.ru_minflt;
+  // have the linter skip these lines because getrusage uses long
+  long prev_maj_pagefaults = this->prev_usage.ru_majflt; // NOLINT
+  long prev_min_pagefaults = this->prev_usage.ru_minflt; // NOLINT
+
   if (getrusage(RUSAGE_THREAD, &this->prev_usage) != 0) {
     return -1;
   }

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -16,6 +16,7 @@
 #include <rttest/rttest.h>
 #include <rttest/utils.hpp>
 
+#include <alloca.h>
 #include <limits.h>
 #include <malloc.h>
 #include <sys/mman.h>
@@ -742,14 +743,8 @@ int Rttest::lock_and_prefault_dynamic()
 
 int rttest_prefault_stack_size(const size_t stack_size)
 {
-  /*
-  unsigned char stack[stack_size];
+  unsigned char * stack = static_cast<unsigned char *>(alloca(stack_size));
   memset(stack, 0, stack_size);
-  return 0;
-  */
-  unsigned char * stack = new unsigned char[stack_size];
-  memset(stack, 0, stack_size);
-  delete[] stack;
   return 0;
 }
 

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -48,7 +48,7 @@ TEST(TestApi, read_args_get_params) {
   struct rttest_params params;
   EXPECT_EQ(0, rttest_get_params(&params));
 
-  EXPECT_EQ(params.iterations, static_cast<uint>(4321));
+  EXPECT_EQ(params.iterations, 4321u);
   EXPECT_EQ(params.update_period.tv_sec, 0);
   EXPECT_EQ(params.update_period.tv_nsec, 50000);
   EXPECT_EQ(params.sched_priority, 42);

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -53,8 +53,8 @@ TEST(TestApi, read_args_get_params) {
   EXPECT_EQ(params.update_period.tv_nsec, 50000);
   EXPECT_EQ(params.sched_priority, 42);
   EXPECT_EQ(params.sched_policy, static_cast<uint>(SCHED_FIFO));
-  EXPECT_EQ(params.stack_size, static_cast<uint>(102400));
-  EXPECT_EQ(params.prefault_dynamic_size, static_cast<uint>(102400));
+  EXPECT_EQ(params.stack_size, 102400u);
+  EXPECT_EQ(params.prefault_dynamic_size, 102400u);
   EXPECT_EQ(strcmp(params.filename, "foo.txt"), 0);
   EXPECT_EQ(0, rttest_finish());
 }
@@ -95,7 +95,7 @@ TEST(TestApi, init) {
   struct rttest_params params;
   EXPECT_EQ(0, rttest_get_params(&params));
 
-  EXPECT_EQ(params.iterations, static_cast<uint>(4321));
+  EXPECT_EQ(params.iterations, 4321u);
   EXPECT_EQ(params.update_period.tv_sec, update_period.tv_sec);
   EXPECT_EQ(params.update_period.tv_nsec, update_period.tv_nsec);
   EXPECT_EQ(params.sched_priority, 42);
@@ -121,7 +121,7 @@ TEST(TestApi, spin_once) {
   EXPECT_EQ(0, rttest_spin_once(test_callback, static_cast<void *>(&counter), &start_time, 0));
   // Block for longer than the update period
   clock_nanosleep(CLOCK_MONOTONIC, 0, &update_period, NULL);
-  EXPECT_EQ(counter, static_cast<uint>(1));
+  EXPECT_EQ(counter, 1u);
 
   EXPECT_EQ(0, rttest_finish());
 }

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -48,13 +48,13 @@ TEST(TestApi, read_args_get_params) {
   struct rttest_params params;
   EXPECT_EQ(0, rttest_get_params(&params));
 
-  EXPECT_EQ(params.iterations, 4321);
+  EXPECT_EQ(params.iterations, static_cast<uint>(4321));
   EXPECT_EQ(params.update_period.tv_sec, 0);
   EXPECT_EQ(params.update_period.tv_nsec, 50000);
   EXPECT_EQ(params.sched_priority, 42);
-  EXPECT_EQ(params.sched_policy, SCHED_FIFO);
-  EXPECT_EQ(params.stack_size, 102400);
-  EXPECT_EQ(params.prefault_dynamic_size, 102400);
+  EXPECT_EQ(params.sched_policy, static_cast<uint>(SCHED_FIFO));
+  EXPECT_EQ(params.stack_size, static_cast<uint>(102400));
+  EXPECT_EQ(params.prefault_dynamic_size, static_cast<uint>(102400));
   EXPECT_EQ(strcmp(params.filename, "foo.txt"), 0);
   EXPECT_EQ(0, rttest_finish());
 }
@@ -95,11 +95,11 @@ TEST(TestApi, init) {
   struct rttest_params params;
   EXPECT_EQ(0, rttest_get_params(&params));
 
-  EXPECT_EQ(params.iterations, 4321);
+  EXPECT_EQ(params.iterations, static_cast<uint>(4321));
   EXPECT_EQ(params.update_period.tv_sec, update_period.tv_sec);
   EXPECT_EQ(params.update_period.tv_nsec, update_period.tv_nsec);
   EXPECT_EQ(params.sched_priority, 42);
-  EXPECT_EQ(params.sched_policy, SCHED_FIFO);
+  EXPECT_EQ(params.sched_policy, static_cast<uint>(SCHED_FIFO));
   EXPECT_EQ(params.stack_size, stack_size);
   EXPECT_EQ(params.prefault_dynamic_size, prefault_dynamic_size);
   EXPECT_EQ(strcmp(params.filename, "foo.txt"), 0);
@@ -121,7 +121,7 @@ TEST(TestApi, spin_once) {
   EXPECT_EQ(0, rttest_spin_once(test_callback, static_cast<void *>(&counter), &start_time, 0));
   // Block for longer than the update period
   clock_nanosleep(CLOCK_MONOTONIC, 0, &update_period, NULL);
-  EXPECT_EQ(counter, 1);
+  EXPECT_EQ(counter, static_cast<uint>(1));
 
   EXPECT_EQ(0, rttest_finish());
 }


### PR DESCRIPTION
This PR enables `-Wall`, `-Wextra`, and `-Wpedantic` and modifies the code to fix thrown warnings.