### PR TITLE
Use strdup instead of strlen/strcpy dance.

### DIFF
--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -448,14 +448,11 @@ int Rttest::init(
   this->params.prefault_dynamic_size = prefault_dynamic_size;
 
   if (filename != nullptr) {
-    size_t n = strlen(filename);
-    this->params.filename = static_cast<char *>(std::malloc(n * sizeof(char) + 1));
+    this->params.filename = strdup(filename);
     if (!this->params.filename) {
-      fprintf(stderr, "Failed to allocate major pagefaults buffer\n");
+      fprintf(stderr, "Failed to allocate filename buffer\n");
       return -1;
     }
-    this->params.filename[n] = 0;
-    strncpy(this->params.filename, filename, n);
     fprintf(stderr, "Writing results to file: %s\n", this->params.filename);
   } else {
     this->params.filename = nullptr;


### PR DESCRIPTION
On Linux release builds, we are getting a new warning from rttest saying
that the strcpy wasn't properly 0-terminating the string.
It is actually a false warning (since we are terminating it
on the line before), but it turns out that we can simplify
this whole thing by using strdup.  Do that here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #101