### PR TITLE
Override get_rcl_allocator for TLSF allocators.

### DIFF
--- a/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
+++ b/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
@@ -20,9 +20,12 @@
 
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <new>
 #include <stdexcept>
 
+#include "rcl/allocator.h"
+#include "rclcpp/allocator/allocator_common.hpp"
 #include "tlsf/tlsf.h"
 
 template<typename T, size_t DefaultPoolSize = 1024 * 1024>
@@ -61,19 +64,21 @@ struct tlsf_heap_allocator
   {
     pool_size = size;
     if (!memory_pool) {
-      memory_pool = new char[pool_size];
-      memset(memory_pool, 0, pool_size);
-      init_memory_pool(pool_size, memory_pool);
+      auto memory = new char[pool_size];
+      memset(memory, 0, pool_size);
+      init_memory_pool(pool_size, memory);
+      memory_pool = std::shared_ptr<char>(
+        memory,
+        [](char * pool) {
+          destroy_memory_pool(pool);
+          delete[] pool;
+        });
     }
     return pool_size;
   }
 
   ~tlsf_heap_allocator()
   {
-    if (memory_pool) {
-      destroy_memory_pool(memory_pool);
-      memory_pool = nullptr;
-    }
   }
 
   // Needed for std::allocator_traits
@@ -98,7 +103,7 @@ struct tlsf_heap_allocator
     typedef tlsf_heap_allocator<U> other;
   };
 
-  char * memory_pool;
+  std::shared_ptr<char> memory_pool;
   size_t pool_size;
 };
 
@@ -135,6 +140,26 @@ constexpr bool operator!=(
   const tlsf_heap_allocator<U, Y> & b) noexcept
 {
   return a.memory_pool != b.memory_pool;
+}
+
+template<typename T, size_t PoolSize>
+rcl_allocator_t get_rcl_allocator(tlsf_heap_allocator<T, PoolSize> allocator)
+{
+  rcl_allocator_t rcl_allocator;
+  rcl_allocator.allocate = [](size_t size, void *) {
+      return tlsf_malloc(size);
+    };
+  rcl_allocator.deallocate = [](void * pointer, void *) {
+      return tlsf_free(pointer);
+    };
+  rcl_allocator.reallocate = [](void * pointer, size_t size, void *) {
+      return tlsf_realloc(pointer, size);
+    };
+  rcl_allocator.zero_allocate = [](size_t nmemb, size_t size, void *) {
+      return tlsf_calloc(nmemb, size);
+    };
+  (void)allocator;  // unused
+  return rcl_allocator;
 }
 
 #endif  // TLSF_CPP__TLSF_HPP_


### PR DESCRIPTION
This removes one more user of the broken generic version of
get_rcl_allocator, which is causing
https://github.com/ros2/rclcpp/issues/1254. This is a companion change to rclcpp #1324.

While there, fix the copy constructor for tslf_heap_allocator. Right now, the allocator keeps an owning ref to a memory pool, and the copy constructor makes a shallow copy of the reference. The first copy of the allocator to go out of scope will invalidate all copies. Instead, use a shared_ptr so that the last copy will clean up the memory pool.

Signed-off-by: Steve Wolter <swolter@google.com>