### PR TITLE
Remove "struct" from rttest_sample_buffer variable declaration.

### DIFF
--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -68,7 +68,7 @@ class Rttest
 {
 private:
   struct rttest_params params;
-  struct rttest_sample_buffer sample_buffer;
+  rttest_sample_buffer sample_buffer;
   struct rusage prev_usage;
 
   pthread_t thread_id;


### PR DESCRIPTION
One cleanup that we missed while changing rttest_sample_buffer
to a class.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>