### PR TITLE
Fix up nonsensical handling of NULL in rttest_get_{params,statistics}

### DIFF
--- a/rttest/include/rttest/rttest.h
+++ b/rttest/include/rttest/rttest.h
@@ -172,6 +172,7 @@ int rttest_get_next_rusage(size_t i);
 int rttest_calculate_statistics(struct rttest_results * results);
 
 /// \brief Get accumulated statistics
+/// \return Error code if results struct is NULL
 int rttest_get_statistics(struct rttest_results * results);
 
 /// \brief Get latency sample at the given iteration.

--- a/rttest/src/rttest.cpp
+++ b/rttest/src/rttest.cpp
@@ -325,17 +325,17 @@ int Rttest::read_args(int argc, char ** argv)
 
 int rttest_get_params(struct rttest_params * params_in)
 {
+  if (params_in == NULL) {
+    return -1;
+  }
+
   auto thread_rttest_instance = get_rttest_thread_instance(pthread_self());
 
   if (!thread_rttest_instance) {
     return -1;
   }
 
-  if (params_in == NULL) {
-    params_in = thread_rttest_instance->get_params();
-  } else {
-    *params_in = *thread_rttest_instance->get_params();
-  }
+  *params_in = *thread_rttest_instance->get_params();
 
   return 0;
 }
@@ -786,6 +786,10 @@ int rttest_calculate_statistics(struct rttest_results * results)
 
 int rttest_get_statistics(struct rttest_results * output)
 {
+  if (output == NULL) {
+    return -1;
+  }
+
   auto thread_rttest_instance = get_rttest_thread_instance(pthread_self());
   if (!thread_rttest_instance) {
     return -1;
@@ -793,12 +797,9 @@ int rttest_get_statistics(struct rttest_results * output)
   if (!thread_rttest_instance->results_initialized) {
     return -1;
   }
-  if (output == NULL) {
-    output = &thread_rttest_instance->results;
-  } else {
-    // if output is not null, try to copy the results struct into the memory location
-    *output = thread_rttest_instance->results;
-  }
+
+  // copy the results struct into the memory location
+  *output = thread_rttest_instance->results;
 
   return 0;
 }

--- a/rttest/test/test_api.cpp
+++ b/rttest/test/test_api.cpp
@@ -46,6 +46,7 @@ TEST(TestApi, read_args_get_params) {
   };
   EXPECT_EQ(0, rttest_read_args(argc, argv));
   struct rttest_params params;
+  EXPECT_EQ(-1, rttest_get_params(NULL));
   EXPECT_EQ(0, rttest_get_params(&params));
 
   EXPECT_EQ(params.iterations, 4321u);
@@ -164,6 +165,7 @@ TEST(TestApi, get_statistics) {
   runtime_min_pgflts = usage.ru_minflt - initial_min_pgflts;
   runtime_maj_pgflts = usage.ru_majflt - initial_maj_pgflts;
   struct rttest_results results;
+  EXPECT_EQ(-1, rttest_get_statistics(NULL));
   EXPECT_EQ(0, rttest_get_statistics(&results));
   EXPECT_EQ(runtime_min_pgflts, results.minor_pagefaults);
   EXPECT_EQ(runtime_maj_pgflts, results.major_pagefaults);


### PR DESCRIPTION
clang static analysis pointed out that when rttest_get_params
or rttest_get_statistics was called with a NULL pointer, there
was a dead store.  That's completely correct; with a NULL
pointer, it would overwrite the pointer, but of course what
got returned was nothing.  Mildly refactor these APIs to instead
return an error with a NULL pointer, and only return data
when there is a valid pointer passed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>