### PR TITLE
Add in the Apache license to tlsf_cpp.

### DIFF
--- a/tlsf_cpp/package.xml
+++ b/tlsf_cpp/package.xml
@@ -6,6 +6,7 @@
   <description>C++ stdlib-compatible wrapper around tlsf allocator and ROS2 examples</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
   <license>GNU Lesser Public License 2.1</license>
+  <license>Apache License 2.0</license>
   <author email="jackie@osrfoundation.org">Jackie Kay</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
The files in here are marked as Apache 2.0, so we should have
the license tag for that.  Since it links against the tlsf
library which is LGPL, we leave the tag for that as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #106 