### PR TITLE
Export modern CMake targets

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -21,13 +21,13 @@ find_package(ament_cmake QUIET)
 if(${ament_cmake_FOUND})
   find_package(Threads REQUIRED)
 
-  include_directories(include)
   add_library(rttest SHARED src/rttest.cpp)
-  target_link_libraries(rttest m stdc++ ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(rttest m stdc++ Threads::Threads)
+  target_include_directories(rttest PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
 
-  ament_export_include_directories(include)
-  set(exported_libraries rttest pthread)
-  ament_export_libraries(${exported_libraries})
+  ament_export_targets(export_rttest)
 
   if(BUILD_TESTING)
     find_package(ament_cmake_gtest REQUIRED)
@@ -39,15 +39,14 @@ if(${ament_cmake_FOUND})
       "test/test_api.cpp"
       TIMEOUT 15
     )
-    if(TARGET gtest_rttest_api)
-      target_link_libraries(gtest_rttest_api ${exported_libraries})
-    endif()
+    target_link_libraries(gtest_rttest_api rttest)
 
     ament_add_gtest(
       gtest_math_utils
       "test/test_math_util.cpp"
       TIMEOUT 15
     )
+    target_link_libraries(gtest_math_utils rttest)
   endif()
 
   ament_package()
@@ -64,6 +63,7 @@ if(${ament_cmake_FOUND})
 
   install(
     TARGETS rttest
+    EXPORT export_rttest
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
   )

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -22,16 +22,25 @@ find_package(tlsf REQUIRED)
 
 include_directories(include)
 
+add_library(tlsf_cpp INTERFACE)
+target_include_directories(tlsf_cpp INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_link_libraries(tlsf_cpp INTERFACE
+  tlsf::tlsf)
+
 add_executable(tlsf_allocator_example
   example/allocator_example.cpp)
-ament_target_dependencies(tlsf_allocator_example
-  "rclcpp"
-  "std_msgs"
-  "tlsf")
+target_link_libraries(tlsf_allocator_example
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
+  tlsf::tlsf)
+
 install(TARGETS tlsf_allocator_example
   DESTINATION bin)
 
-ament_export_include_directories(include)
+ament_export_targets(export_tlsf_cpp)
+
 ament_export_dependencies("tlsf")
 
 if(BUILD_TESTING)
@@ -51,8 +60,10 @@ if(BUILD_TESTING)
     if(TARGET ${target}${target_suffix})
       target_compile_definitions(${target}${target_suffix}
         PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-      ament_target_dependencies(${target}${target_suffix}
-        "rclcpp" "std_msgs" "tlsf")
+      target_link_libraries(${target}${target_suffix}
+        rclcpp::rclcpp
+        ${std_msgs_TARGETS}
+        tlsf::tlsf)
     endif()
   endmacro()
 
@@ -64,3 +75,5 @@ ament_package()
 install(DIRECTORY include/
   DESTINATION include
 )
+
+install(TARGETS tlsf_cpp EXPORT export_tlsf_cpp)


### PR DESCRIPTION
Part of ament/ament_cmake#365

This makes rttest and tlsf_cpp export modern CMake targets instead of old-style CMake variables.