### PR TITLE
Addressing issues found in Humble testing

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -58,7 +58,7 @@ if(${ament_cmake_FOUND})
 
   install(
     PROGRAMS scripts/rttest_plot
-    DESTINATION bin
+    DESTINATION lib/${PROJECT_NAME}
   )
 
   install(

--- a/rttest/README.md
+++ b/rttest/README.md
@@ -34,6 +34,12 @@ make
 ./example_loop
 ```
 
+Note that if this is run in a Docker container, the `IPC_LOCK` capability must be added to the container capabilities.
+This can be managed via the `--cap-add` flag:
+```
+docker run --cap-add IPC_LOCK
+```
+
 ## Command line arguments
 
 Passing `argc` and `argv` of an instrumented main function to `rttest_read_args` will enable command line arguments for the instrumented function.
@@ -59,4 +65,4 @@ Default value is 1000.
 -tp Set the thread priority of all threads launched by the test program.
 Individual thread priority can be set using the `rttest_set_sched_priority` command.
 
--f Specify the name of the file for writing the collected data. Plot this data file using the `rttest_plot.py` script provided in `scripts`.
+-f Specify the name of the file for writing the collected data. Plot this data file using the `rttest_plot` script provided in `scripts`.

--- a/rttest/examples/CMakeLists.txt
+++ b/rttest/examples/CMakeLists.txt
@@ -5,4 +5,4 @@ project(rttest_examples)
 find_package(rttest REQUIRED)
 
 add_executable(example_loop example_loop.c)
-target_link_libraries(example_loop rttest::rttest) 
+target_link_libraries(example_loop rttest::rttest)

--- a/rttest/examples/CMakeLists.txt
+++ b/rttest/examples/CMakeLists.txt
@@ -4,8 +4,5 @@ project(rttest_examples)
 
 find_package(rttest REQUIRED)
 
-link_directories(${rttest_LIBRARY_DIR})
-include_directories(${rttest_INCLUDE_DIRS})
-
 add_executable(example_loop example_loop.c)
-target_link_libraries(example_loop ${rttest_LIBRARIES})
+target_link_libraries(example_loop rttest::rttest) 

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -35,8 +35,9 @@ target_link_libraries(tlsf_allocator_example
   ${std_msgs_TARGETS}
   tlsf_cpp)
 
-install(TARGETS tlsf_allocator_example
-  DESTINATION bin)
+install(TARGETS 
+  tlsf_allocator_example
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_export_targets(export_tlsf_cpp)
 

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(tlsf_allocator_example
   ${std_msgs_TARGETS}
   tlsf_cpp)
 
-install(TARGETS 
+install(TARGETS
   tlsf_allocator_example
   DESTINATION lib/${PROJECT_NAME})
 


### PR DESCRIPTION
Correcting installation locations for scripts as well as updating the example to use the modern CMake targets.

Found via osrf/ros2_test_cases#211, osrf/ros2_test_cases#221 osrf/ros2_test_cases#223