### PR TITLE
Explicitly link rt, necessary for conda

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -23,6 +23,7 @@ if(${ament_cmake_FOUND})
 
   add_library(rttest SHARED src/rttest.cpp)
   target_link_libraries(rttest PRIVATE m stdc++ Threads::Threads)
+  target_link_libraries(rttest PUBLIC rt)
   target_include_directories(rttest PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
@@ -80,7 +81,7 @@ else()
 
   find_package(Threads REQUIRED)
   add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
-  target_link_libraries(rttest m stdc++ ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(rttest m stdc++ rt ${CMAKE_THREAD_LIBS_INIT})
 
   include_directories(rttest ${PROJECT_SOURCE_DIR}/include)
 


### PR DESCRIPTION
When building with Conda, I found that `rt` wasn't being explicitly linked in.  While this is probably okay in many cases, it doesn't work in the conda environment.

The build resulted in missing symbols like `clock_gettime`: https://man7.org/linux/man-pages/man2/clock_gettime.2.html

Signed-off-by: Michael Carroll <michael@openrobotics.org>