### PR TITLE
Reduce the number of files we compile.

### DIFF
--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -31,10 +31,11 @@ target_link_libraries(tlsf_cpp INTERFACE
 
 add_executable(tlsf_allocator_example
   example/allocator_example.cpp)
-target_link_libraries(tlsf_allocator_example
+target_link_libraries(tlsf_allocator_example PRIVATE
   rclcpp::rclcpp
   ${std_msgs_TARGETS}
-  tlsf_cpp)
+  tlsf_cpp
+)
 
 install(TARGETS
   tlsf_allocator_example
@@ -48,23 +49,25 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  # get typesupport of rmw implementation to include / link against the corresponding interfaces
+  find_package(ament_cmake_gtest REQUIRED)
 
-  macro(add_gtest)
-    ament_add_gtest(test_tlsf${target_suffix} "test/test_tlsf.cpp" TIMEOUT 15
+  ament_add_gtest_executable(test_tlsf test/test_tlsf.cpp)
+  if(TARGET test_tlsf${target_suffix})
+    target_link_libraries(test_tlsf
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      tlsf_cpp
+    )
+  endif()
+
+  function(add_gtest)
+    ament_add_gtest_test(test_tlsf
+      TEST_NAME test_tlsf${target_suffix}
+      TIMEOUT 15
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation})
-    if(TARGET test_tlsf${target_suffix})
-      target_compile_definitions(test_tlsf${target_suffix}
-        PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-      target_link_libraries(test_tlsf${target_suffix}
-        rclcpp::rclcpp
-        ${std_msgs_TARGETS}
-        tlsf_cpp)
-    endif()
-  endmacro()
-
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        RMW_IMPLEMENTATION=${rmw_implementation})
+  endfunction()
   call_for_each_rmw_implementation(add_gtest)
 endif()
 

--- a/tlsf_cpp/test/test_tlsf.cpp
+++ b/tlsf_cpp/test/test_tlsf.cpp
@@ -24,19 +24,12 @@
 #include "std_msgs/msg/u_int32.hpp"
 #include "tlsf_cpp/tlsf.hpp"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
 template<typename T = void>
 using TLSFAllocator = tlsf_heap_allocator<T>;
 
 using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
 
-class CLASSNAME (AllocatorTest, RMW_IMPLEMENTATION) : public ::testing::Test
+class AllocatorTest : public ::testing::Test
 {
 protected:
   std::string test_name_;
@@ -85,15 +78,10 @@ protected:
 
     executor_->add_node(node_);
   }
-
-  CLASSNAME(AllocatorTest, RMW_IMPLEMENTATION)() {
-  }
-
-  ~CLASSNAME(AllocatorTest, RMW_IMPLEMENTATION)() {
-  }
 };
 
-TEST_F(CLASSNAME(AllocatorTest, RMW_IMPLEMENTATION), type_traits_test) {
+TEST_F(AllocatorTest, type_traits_test)
+{
   using UInt32TLSFAllocator = TLSFAllocator<std_msgs::msg::UInt32>;
   using UInt32TLSFDeleter = rclcpp::allocator::Deleter<UInt32TLSFAllocator, std_msgs::msg::UInt32>;
 
@@ -125,7 +113,8 @@ TEST_F(CLASSNAME(AllocatorTest, RMW_IMPLEMENTATION), type_traits_test) {
 // TODO(wjwwood): re-enable this test when the allocator has been added back to the
 //   intra-process manager.
 //   See: https://github.com/ros2/realtime_support/pull/80#issuecomment-545419570
-TEST_F(CLASSNAME(AllocatorTest, RMW_IMPLEMENTATION), allocator_unique_ptr) {
+TEST_F(AllocatorTest, allocator_unique_ptr)
+{
   initialize(true, "allocator_unique_ptr");
   size_t counter = 0;
   auto callback =


### PR DESCRIPTION
We only need to build the test once, and then we can use the RMW_IMPLEMENTATION environment variable to run it for various RMWs.