### PR TITLE
Don't try to build on BSD

### DIFF
--- a/rttest/CMakeLists.txt
+++ b/rttest/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rttest)
 
-if(WIN32 OR APPLE OR ANDROID)
+if(WIN32 OR APPLE OR ANDROID OR BSD)
   message(STATUS "rttest is only supported on Linux, skipping...")
   return()
 endif()


### PR DESCRIPTION
The 'BSD' variable was [added in CMake 3.25](https://cmake.org/cmake/help/latest/variable/BSD.html). Note that variables which are not defined will evaluate to 'False', so this shouldn't regress platforms using CMake versions older than 3.25.