### PR TITLE
Explicitly shutdown context before test exits

### DIFF
--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tlsf REQUIRED)
@@ -55,6 +56,7 @@ if(BUILD_TESTING)
   if(TARGET test_tlsf${target_suffix})
     target_link_libraries(test_tlsf
       rclcpp::rclcpp
+      rcpputils::rcpputils
       ${std_msgs_TARGETS}
       tlsf_cpp
     )

--- a/tlsf_cpp/package.xml
+++ b/tlsf_cpp/package.xml
@@ -30,6 +30,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
 
   <export>

--- a/tlsf_cpp/test/test_tlsf.cpp
+++ b/tlsf_cpp/test/test_tlsf.cpp
@@ -21,6 +21,8 @@
 #include "rclcpp/strategies/allocator_memory_strategy.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "rcpputils/scope_exit.hpp"
+
 #include "std_msgs/msg/u_int32.hpp"
 #include "tlsf_cpp/tlsf.hpp"
 
@@ -154,6 +156,9 @@ TEST_F(AllocatorTest, allocator_unique_ptr)
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
+  // Always shutdown the ROS context.
+  auto always_shutdown = rcpputils::make_scope_exit(
+    []() {rclcpp::shutdown();});
   ::testing::InitGoogleTest(&argc, argv);
 
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Rely on `rcpputils::make_scope_exit` to shutdown the `rclcpp` context before the program exits. 
