### PR TITLE
Allow zenoh tests to run with multicast

### DIFF
--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -63,12 +63,23 @@ if(BUILD_TESTING)
   endif()
 
   function(add_gtest)
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     ament_add_gtest_test(test_tlsf
       TEST_NAME test_tlsf${target_suffix}
       TIMEOUT 15
       ENV
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        RMW_IMPLEMENTATION=${rmw_implementation})
+        RMW_IMPLEMENTATION=${rmw_implementation}
+        ${rmw_implementation_env_var}
+    )
   endfunction()
   call_for_each_rmw_implementation(add_gtest)
 endif()


### PR DESCRIPTION
 See https://github.com/ros2/rmw_zenoh/issues/567

To test this PR, we can run the usual CI jobs to show there are no regressions and additionally run a CI job with a copy of the ros2.repos file from https://github.com/ros2/ros2/pull/1649 with CI Scripts branch set to yadu/cargo