### PR TITLE
tlsf_cpp: add test isolation

### DIFF
--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -15,7 +15,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
@@ -50,7 +49,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
 
   ament_add_gtest_executable(test_tlsf test/test_tlsf.cpp)
   if(TARGET test_tlsf${target_suffix})

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
@@ -63,7 +63,7 @@ if(BUILD_TESTING)
   endif()
 
   function(add_gtest)
-    ament_add_gtest_test(test_tlsf
+    ament_add_ros_isolated_gtest_test(test_tlsf
       TEST_NAME test_tlsf${target_suffix}
       TIMEOUT 15
       ENV

--- a/tlsf_cpp/package.xml
+++ b/tlsf_cpp/package.xml
@@ -29,7 +29,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>rcpputils</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
 


### PR DESCRIPTION
## Description

As discussed in https://github.com/ros2/rmw_zenoh/issues/881#issuecomment-3891134977, this PR adds tests isolation to all tests initializing a Context or a Node, in order to start a Zenoh router in case of `rmw_zenoh_cpp`.

This fix eliminates the log message in `test_tlsf` with `RMW_IMPLEMENTATION=rmw_zenoh_cpp`:
```log
4: 2026-02-24T14:18:02.965383Z  WARN ThreadId(06) zenoh::net::runtime::orchestrator: Scouting delay elapsed before start conditions are met.
```

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
