### PR TITLE
Removed deprecation warnings

### DIFF
--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -6,15 +6,16 @@ if(WIN32 OR APPLE OR ANDROID)
   return()
 endif()
 
-# Default to C++17
+# Default to C++20
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
+find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
@@ -27,6 +28,7 @@ target_include_directories(tlsf_cpp INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(tlsf_cpp INTERFACE
+  rcl::rcl
   tlsf::tlsf)
 
 add_executable(tlsf_allocator_example
@@ -43,7 +45,7 @@ install(TARGETS
 
 ament_export_targets(export_tlsf_cpp)
 
-ament_export_dependencies("tlsf")
+ament_export_dependencies("rcl" "tlsf")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/tlsf_cpp/CMakeLists.txt
+++ b/tlsf_cpp/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 
 find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tlsf REQUIRED)
@@ -52,16 +51,15 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_ros REQUIRED)
+  find_package(rcpputils REQUIRED)
 
   ament_add_gtest_executable(test_tlsf test/test_tlsf.cpp)
-  if(TARGET test_tlsf${target_suffix})
-    target_link_libraries(test_tlsf
-      rclcpp::rclcpp
-      rcpputils::rcpputils
-      std_msgs::std_msgs
-      tlsf_cpp
-    )
-  endif()
+  target_link_libraries(test_tlsf
+    rclcpp::rclcpp
+    rcpputils::rcpputils
+    std_msgs::std_msgs
+    tlsf_cpp
+  )
 
   function(add_gtest)
     ament_add_ros_isolated_gtest_test(test_tlsf
@@ -74,10 +72,10 @@ if(BUILD_TESTING)
   call_for_each_rmw_implementation(add_gtest)
 endif()
 
-ament_package()
-
 install(DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS tlsf_cpp EXPORT export_tlsf_cpp)
+
+ament_package()

--- a/tlsf_cpp/example/allocator_example.cpp
+++ b/tlsf_cpp/example/allocator_example.cpp
@@ -25,6 +25,30 @@
 template<typename T>
 using TLSFAllocator = tlsf_heap_allocator<T>;
 
+// Explicit member-function specialization for AllocatorMemoryStrategy<tlsf_heap_allocator<void>>.
+// AllocatorMemoryStrategy::get_allocator() calls the deprecated get_rcl_allocator() free
+// function; by specializing the member we replace the entire body, so the deprecated call is
+// never instantiated.  tlsf_heap_allocator stores its pool in a char* and initialises it via
+// init_memory_pool(), which also registers it as the TLSF global pool, so the global
+// tlsf_malloc/tlsf_free functions reach the same pool as the pool-specific malloc_ex/free_ex.
+namespace rclcpp::memory_strategies::allocator_memory_strategy
+{
+template<>
+rcl_allocator_t
+AllocatorMemoryStrategy<tlsf_heap_allocator<void>>::get_allocator()
+{
+  rcl_allocator_t rcl_alloc = rcl_get_default_allocator();
+  rcl_alloc.allocate = [](size_t size, void *) -> void * {return tlsf_malloc(size);};
+  rcl_alloc.deallocate = [](void * ptr, void *) {tlsf_free(ptr);};
+  rcl_alloc.reallocate =
+    [](void * ptr, size_t size, void *) -> void * {return tlsf_realloc(ptr, size);};
+  rcl_alloc.zero_allocate =
+    [](size_t n, size_t s, void *) -> void * {return tlsf_calloc(n, s);};
+  rcl_alloc.state = nullptr;
+  return rcl_alloc;
+}
+}  // namespace rclcpp::memory_strategies::allocator_memory_strategy
+
 int main(int argc, char ** argv)
 {
   using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;

--- a/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
+++ b/tlsf_cpp/include/tlsf_cpp/tlsf.hpp
@@ -20,9 +20,13 @@
 
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <new>
 #include <stdexcept>
+#include <type_traits>
+#include <utility>
 
+#include "rcl/allocator.h"
 #include "tlsf/tlsf.h"
 
 template<typename T, size_t DefaultPoolSize = 1024 * 1024>
@@ -92,6 +96,25 @@ struct tlsf_heap_allocator
     tlsf_free(ptr);
   }
 
+  rcl_allocator_t get_rcl_allocator()
+  {
+    rcl_allocator_t allocator = rcl_get_default_allocator();
+    allocator.allocate = [](size_t size, void * state) -> void * {
+        return malloc_ex(size, state);
+      };
+    allocator.deallocate = [](void * ptr, void * state) {
+        free_ex(ptr, state);
+      };
+    allocator.reallocate = [](void * ptr, size_t size, void * state) -> void * {
+        return realloc_ex(ptr, size, state);
+      };
+    allocator.zero_allocate = [](size_t n, size_t size, void * state) -> void * {
+        return calloc_ex(n, size, state);
+      };
+    allocator.state = memory_pool;
+    return allocator;
+  }
+
   template<typename U>
   struct rebind
   {
@@ -136,5 +159,6 @@ constexpr bool operator!=(
 {
   return a.memory_pool != b.memory_pool;
 }
+
 
 #endif  // TLSF_CPP__TLSF_HPP_

--- a/tlsf_cpp/package.xml
+++ b/tlsf_cpp/package.xml
@@ -15,13 +15,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>ament_cmake</build_depend>
+  <build_depend>rcl</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tlsf</build_depend>
 
-  <exec_depend>ament_cmake</exec_depend>
+  <exec_depend>rcl</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rmw</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
## Description

There are some warning when compiling with clang

```
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/subscription_options.hpp:200:35: warning: 'get_rcl_allocator<char, tlsf_heap_allocator<char>, nullptr>' is deprecated: Conversion of C++ allocators to C style is not valid, as the size on deallocatecan not be determined. This will be remove in future versions of ros. To suppress this warningdefine the method 'rcl_allocator_t get_rcl_allocator()' on your allocator [-Wdeprecated-declarations]
  200 |         return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
      |                                   ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/subscription_options.hpp:131:30: note: in instantiation of member function 'rclcpp::SubscriptionOptionsWithAllocator<tlsf_heap_allocator<void>>::get_rcl_allocator' requested here
  131 |     result.allocator = this->get_rcl_allocator();
      |                              ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/subscription.hpp:132:15: note: in instantiation of member function 'rclcpp::SubscriptionOptionsWithAllocator<tlsf_heap_allocator<void>>::to_rcl_subscription_options' requested here
  132 |       options.to_rcl_subscription_options(qos),
      |               ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/allocator.h:173:24: note: in instantiation of member function 'rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>::Subscription' requested here
  173 |     ::new ((void*)__p) _Up(std::forward<_Args>(__args)...);
      |                        ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/allocator_traits.h:296:9: note: in instantiation of function template specialization 'std::allocator<rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>>::construct<rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::node_interfaces::NodeBaseInterface *&, const rosidl_message_type_support_t &, const std::string &, const rclcpp::QoS &, const rclcpp::AnySubscriptionCallback<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>> &, const rclcpp::SubscriptionOptionsWithAllocator<tlsf_heap_allocator<void>> &, const std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>> &, const std::shared_ptr<rclcpp::topic_statistics::SubscriptionTopicStatistics> &>' requested here
  296 |     __a.construct(__p, std::forward<_Args>(__args)...);
      |         ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/shared_ptr.h:265:33: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>>>::construct<rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::node_interfaces::NodeBaseInterface *&, const rosidl_message_type_support_t &, const std::string &, const rclcpp::QoS &, const rclcpp::AnySubscriptionCallback<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>> &, const rclcpp::SubscriptionOptionsWithAllocator<tlsf_heap_allocator<void>> &, const std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>> &, const std::shared_ptr<rclcpp::topic_statistics::SubscriptionTopicStatistics> &, void>' requested here
  265 |     allocator_traits<_TpAlloc>::construct(__tmp, __get_elem(), std::forward<_Args>(__args)...);
      |                                 ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/shared_ptr.h:823:51: note: (skipping 3 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
  823 |   ::new ((void*)std::addressof(*__guard.__get())) _ControlBlock(__a, std::forward<_Args>(__args)...);
      |                                                   ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/subscription_factory.hpp:106:54: note: in instantiation of function template specialization 'rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>::make_shared<rclcpp::node_interfaces::NodeBaseInterface *&, const rosidl_message_type_support_t &, const std::string &, const rclcpp::QoS &, const rclcpp::AnySubscriptionCallback<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>> &, const rclcpp::SubscriptionOptionsWithAllocator<tlsf_heap_allocator<void>> &, const std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>> &, const std::shared_ptr<rclcpp::topic_statistics::SubscriptionTopicStatistics> &>' requested here
  106 |       auto sub = Subscription<MessageT, AllocatorT>::make_shared(
      |                                                      ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/create_subscription.hpp:121:26: note: in instantiation of function template specialization 'rclcpp::create_subscription_factory<std_msgs::msg::UInt32_<std::allocator<void>>, (lambda at /home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:65:19) &, tlsf_heap_allocator<void>, rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>>' requested here
  121 |   auto factory = rclcpp::create_subscription_factory<MessageT>(
      |                          ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/create_subscription.hpp:189:26: note: in instantiation of function template specialization 'rclcpp::detail::create_subscription<std_msgs::msg::UInt32_<std::allocator<void>>, (lambda at /home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:65:19) &, tlsf_heap_allocator<void>, rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::Node, rclcpp::Node>' requested here
  189 |   return rclcpp::detail::create_subscription<
      |                          ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/node_impl.hpp:100:18: note: in instantiation of function template specialization 'rclcpp::create_subscription<std_msgs::msg::UInt32_<std::allocator<void>>, (lambda at /home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:65:19) &, tlsf_heap_allocator<void>, rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::Node>' requested here
  100 |   return rclcpp::create_subscription<MessageT>(
      |                  ^
/home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:83:27: note: in instantiation of function template specialization 'rclcpp::Node::create_subscription<std_msgs::msg::UInt32_<std::allocator<void>>, (lambda at /home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:65:19) &, tlsf_heap_allocator<void>, rclcpp::Subscription<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32_<std::allocator<void>>, tlsf_heap_allocator<void>>>' requested here
   83 |   auto subscriber = node->create_subscription<std_msgs::msg::UInt32>(
      |                           ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/allocator/allocator_common.hpp:123:3: note: 'get_rcl_allocator<char, tlsf_heap_allocator<char>, nullptr>' has been explicitly marked deprecated here
  123 | [[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
      |   ^
In file included from /home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:21:
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/strategies/allocator_memory_strategy.hpp:521:33: warning: 'get_rcl_allocator<void *, tlsf_heap_allocator<void *>, nullptr>' is deprecated: Conversion of C++ allocators to C style is not valid, as the size on deallocatecan not be determined. This will be remove in future versions of ros. To suppress this warningdefine the method 'rcl_allocator_t get_rcl_allocator()' on your allocator [-Wdeprecated-declarations]
  521 |       return rclcpp::allocator::get_rcl_allocator<void *, VoidAlloc>(*allocator_.get());
      |                                 ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/strategies/allocator_memory_strategy.hpp:55:12: note: in instantiation of member function 'rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>::get_allocator' requested here
   55 |   explicit AllocatorMemoryStrategy(std::shared_ptr<Alloc> allocator)
      |            ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/allocator.h:173:24: note: in instantiation of member function 'rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>::AllocatorMemoryStrategy' requested here
  173 |     ::new ((void*)__p) _Up(std::forward<_Args>(__args)...);
      |                        ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/allocator_traits.h:296:9: note: in instantiation of function template specialization 'std::allocator<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>>::construct<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>, std::shared_ptr<tlsf_heap_allocator<void>> &>' requested here
  296 |     __a.construct(__p, std::forward<_Args>(__args)...);
      |         ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/shared_ptr.h:265:33: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>>>::construct<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>, std::shared_ptr<tlsf_heap_allocator<void>> &, void>' requested here
  265 |     allocator_traits<_TpAlloc>::construct(__tmp, __get_elem(), std::forward<_Args>(__args)...);
      |                                 ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/shared_ptr.h:823:51: note: in instantiation of function template specialization 'std::__shared_ptr_emplace<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>, std::allocator<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>>>::__shared_ptr_emplace<std::shared_ptr<tlsf_heap_allocator<void>> &, std::allocator<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>>, 0>' requested here
  823 |   ::new ((void*)std::addressof(*__guard.__get())) _ControlBlock(__a, std::forward<_Args>(__args)...);
      |                                                   ^
/usr/lib/llvm-18/bin/../include/c++/v1/__memory/shared_ptr.h:831:15: note: in instantiation of function template specialization 'std::allocate_shared<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>, std::allocator<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>>, std::shared_ptr<tlsf_heap_allocator<void>> &, void>' requested here
  831 |   return std::allocate_shared<_Tp>(allocator<_Tp>(), std::forward<_Args>(__args)...);
      |               ^
/home/ahcorde/ros2_rolling/src/ros2/realtime_support/tlsf_cpp/example/allocator_example.cpp:89:10: note: in instantiation of function template specialization 'std::make_shared<rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<tlsf_heap_allocator<void>>, std::shared_ptr<tlsf_heap_allocator<void>> &, void>' requested here
   89 |     std::make_shared<AllocatorMemoryStrategy<Alloc>>(alloc);
      |          ^
/home/ahcorde/ros2_rolling/install/include/rclcpp/rclcpp/allocator/allocator_common.hpp:123:3: note: 'get_rcl_allocator<void *, tlsf_heap_allocator<void *>, nullptr>' has been explicitly marked deprecated here
  123 | [[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
      |   ^
4 warnings generated.

```
### Did you use Generative AI?

Claude Sonnet 4.6
