### PR TITLE
fix: Removed AllocatorMemoryStrategy

### DIFF
--- a/tlsf_cpp/example/allocator_example.cpp
+++ b/tlsf_cpp/example/allocator_example.cpp
@@ -18,7 +18,6 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp/strategies/allocator_memory_strategy.hpp"
 #include "std_msgs/msg/u_int32.hpp"
 #include "tlsf_cpp/tlsf.hpp"
 
@@ -27,7 +26,6 @@ using TLSFAllocator = tlsf_heap_allocator<T>;
 
 int main(int argc, char ** argv)
 {
-  using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
   using Alloc = TLSFAllocator<void>;
   rclcpp::init(argc, argv);
 
@@ -83,13 +81,7 @@ int main(int argc, char ** argv)
   auto subscriber = node->create_subscription<std_msgs::msg::UInt32>(
     "allocator_example", 10, callback, subscription_options, msg_mem_strat);
 
-  // Create a MemoryStrategy, which handles the allocations made by the Executor during the
-  // execution path, and inject the MemoryStrategy into the Executor.
-  std::shared_ptr<rclcpp::memory_strategy::MemoryStrategy> memory_strategy =
-    std::make_shared<AllocatorMemoryStrategy<Alloc>>(alloc);
-
   rclcpp::ExecutorOptions options;
-  options.memory_strategy = memory_strategy;
   rclcpp::executors::SingleThreadedExecutor executor(options);
 
   // Add our node to the executor.
@@ -105,7 +97,6 @@ int main(int argc, char ** argv)
   rclcpp::allocator::set_allocator_for_deleter(&message_deleter, &message_alloc);
 
   rclcpp::sleep_for(std::chrono::milliseconds(1));
-
 
   uint32_t i = 0;
   while (rclcpp::ok() && i < 100) {

--- a/tlsf_cpp/test/test_tlsf.cpp
+++ b/tlsf_cpp/test/test_tlsf.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <type_traits>
 
-#include "rclcpp/strategies/allocator_memory_strategy.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "rcpputils/scope_exit.hpp"
@@ -29,8 +28,6 @@
 template<typename T = void>
 using TLSFAllocator = tlsf_heap_allocator<T>;
 
-using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
-
 class AllocatorTest : public ::testing::Test
 {
 protected:
@@ -38,7 +35,6 @@ protected:
 
   rclcpp::Node::SharedPtr node_;
   rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
-  rclcpp::memory_strategy::MemoryStrategy::SharedPtr memory_strategy_;
   rclcpp::Publisher<
     std_msgs::msg::UInt32, TLSFAllocator<void>>::SharedPtr publisher_;
   rclcpp::message_memory_strategy::MessageMemoryStrategy<
@@ -71,11 +67,8 @@ protected:
       rclcpp::message_memory_strategy::MessageMemoryStrategy<
         std_msgs::msg::UInt32, TLSFAllocator<void>>>(alloc);
     publisher_ = node_->create_publisher<std_msgs::msg::UInt32>(name, 10, publisher_options_);
-    memory_strategy_ =
-      std::make_shared<AllocatorMemoryStrategy<TLSFAllocator<void>>>(alloc);
 
     rclcpp::ExecutorOptions executor_options;
-    executor_options.memory_strategy = memory_strategy_;
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>(executor_options);
 
     executor_->add_node(node_);


### PR DESCRIPTION
This did nothing since the jazzy release.

companion to https://github.com/ros2/rclcpp/pull/3136
