### PR TITLE
Call rclcpp::shutdown at the end of the example.

### DIFF
--- a/tlsf_cpp/example/allocator_example.cpp
+++ b/tlsf_cpp/example/allocator_example.cpp
@@ -112,5 +112,7 @@ int main(int argc, char ** argv)
     executor.spin_some();
   }
 
+  rclcpp::shutdown();
+
   return 0;
 }


### PR DESCRIPTION
## Description

As in other places, we can't guarantee the destruction order, so it is possible that we have dangling pointers and class_loader gets upset.  Side-step the issue by explicitly shutting down rclcpp.

Fixes https://github.com/ros2/lyrical_tutorial_party/issues/376

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

N/A